### PR TITLE
Fix: Streamline GPG configuration in Maven Central release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,4 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Build and deploy
-        run: |
-          mvn clean deploy --batch-mode \
-          -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        run: mvn clean deploy --batch-mode


### PR DESCRIPTION
The `setup-java` GitHub action, when provided with `gpg-private-key` and `gpg-passphrase`, configures GPG for use by Maven. Explicitly passing `-Dgpg.passphrase` to the `mvn deploy` command is redundant and can potentially interfere with the setup.

This commit removes the `-Dgpg.passphrase` argument from the `mvn clean deploy` command in the `.github/workflows/release.yml` workflow. This relies on the `central-publishing-maven-plugin` and `maven-gpg-plugin` to pick up the GPG configuration from the environment set up by the `setup-java` action.