### PR TITLE
Revert: Re-add GPG passphrase to Maven deploy command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,4 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Build and deploy
-        run: |
-          mvn clean deploy --batch-mode \
-          -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        run: mvn clean deploy --batch-mode -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
This reverts the previous commit that removed the -Dgpg.passphrase argument from the `mvn clean deploy` command.

The `maven-gpg-plugin` was unable to find a `settings-security.xml` file to decrypt the GPG passphrase, leading to a build failure. Re-adding the passphrase directly to the command line is intended to provide the plugin with the necessary credentials directly, bypassing the need for `settings-security.xml` for this specific purpose in this setup.